### PR TITLE
Fixes the case when a closure is provided to a().

### DIFF
--- a/src/Extensions/Helpers.php
+++ b/src/Extensions/Helpers.php
@@ -265,7 +265,7 @@ class Helpers implements ExtensionInterface, TemplateAware
      */
     public function asArray($var, $default = [], $filter = null, $forceRaw = false)
     {
-        $raw = $this->raw($var, (array) $default, $filter);
+        $raw = $this->raw($var, $default, $filter);
 
         return \Foil\arraize($raw, ($this->autoescape && ! $forceRaw));
     }


### PR DESCRIPTION
I just tried to provide a closure as a default to a() and got some unexpected results.

The problem is that it gets cast to an array and then never gets invoked.
I could just use v() but then I have to manually arraize.

Removing the cast fixed my issue, if there is a better way let me know.
