### PR TITLE
Do not trim output - fixes #44

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -304,7 +304,7 @@ class Engine implements EngineInterface, TemplateAware, FinderAware
         }
         $template = $this->stack()->factory($path, $this, $class);
         $this->events->fire('f.template.render', $template, $data);
-        $output = trim($template->render($data));
+        $output = $template->render($data);
         $this->events->fire('f.template.renderered', $template, $output, $this->status);
 
         return $output;


### PR DESCRIPTION
Hi @Giuseppe-Mazzapica  - here's the PR. Hope it's what you had in mind.

Unit tests pass after the change:

```
PHPUnit 5.6.1 by Sebastian Bergmann and contributors.

Error:         No code coverage driver is available

...............................................................  63 / 209 ( 30%)
............................................................... 126 / 209 ( 60%)
............................................................... 189 / 209 ( 90%)
....................                                            209 / 209 (100%)

Time: 617 ms, Memory: 22.00MB

OK (209 tests, 435 assertions)
```