### PR TITLE
Completing trim() fix in #44 which was only partly solved by #45

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -286,7 +286,7 @@ class Template implements AliasAllowedTemplateInterface
         /** @noinspection PhpIncludeInspection */
         require $path;
         $this->lastBuffer = $this->buffer;
-        $this->buffer = trim(ob_get_clean());
+        $this->buffer = ob_get_clean();
 
         return $this->buffer;
     }

--- a/tests/src/Functional/SimpleRenderTest.php
+++ b/tests/src/Functional/SimpleRenderTest.php
@@ -25,7 +25,7 @@ class SimpleRenderTest extends TestCaseFunctional
     public function testSimpleRender()
     {
         $this->initFoil();
-        $render = preg_replace('/[\s]+/', ' ', $this->engine->render('main'));
+        $render = trim( preg_replace('/[\s]+/', ' ', $this->engine->render('main')) );
         assertSame('Hello Alone NO YES', $render);
     }
 
@@ -38,7 +38,7 @@ class SimpleRenderTest extends TestCaseFunctional
         $render1 = preg_replace('/[\s]+/', ' ', $this->engine->render('main'));
         $render2 = preg_replace('/[\s]+/', ' ', $this->engine->render('main'));
         $render3 = preg_replace('/[\s]+/', ' ', $this->engine->render('main'));
-        assertSame('Hello Alone NO YES', $render1);
+        assertSame('Hello Alone NO YES', trim( $render1 ));
         assertSame($render1, $render2);
         assertSame($render2, $render3);
     }
@@ -81,7 +81,7 @@ class SimpleRenderTest extends TestCaseFunctional
         );
         $render1 = preg_replace('/[\s]+/', ' ', $this->engine->render('second', ['foo' => 'Foo!']));
         $render2 = preg_replace('/[\s]+/', ' ', $this->engine->render('second', ['foo' => 'Foo!']));
-        assertSame('Hello Bar! World Foo! Alone I Win YES MAN', $render1);
+        assertSame('Hello Bar! World Foo! Alone I Win YES MAN', trim($render1));
         assertSame($render1, $render2);
         assertSame('Buffalo Bill', trim($buffer));
     }


### PR DESCRIPTION
Hi again @Giuseppe-Mazzapica 

Looks like my last commit missed another `trim()` deeper in the code. This one completes the work in #44 and #45 and has been tested to produce expected output.

I've also had to update the tests (which all pass now). I've done this judiciously - using `trim()` when testing against hard coded strings but not when testing renders against one another.

Thanks a million,
Barry